### PR TITLE
gitlab 16.8.0 ruby build fixes

### DIFF
--- a/pkgs/applications/version-management/gitlab/default.nix
+++ b/pkgs/applications/version-management/gitlab/default.nix
@@ -1,7 +1,9 @@
 { stdenv, lib, fetchurl, fetchpatch, fetchFromGitLab, bundlerEnv
 , ruby_3_1, tzdata, git, nettools, nixosTests, nodejs, openssl
+, defaultGemConfig, buildRubyGem
 , gitlabEnterprise ? false, callPackage, yarn
 , prefetch-yarn-deps, replace, file, cacert, fetchYarnDeps, makeWrapper, pkg-config
+, cargo, rustc, rustPlatform
 }:
 
 let
@@ -19,19 +21,49 @@ let
     name = "gitlab-env-${version}";
     ruby = ruby_3_1;
     gemdir = ./rubyEnv;
-    gemset =
-      let x = import (gemdir + "/gemset.nix") src;
-      in x // {
-        gpgme = x.gpgme // {
+    gemset = import (gemdir + "/gemset.nix") src;
+    gemConfig = defaultGemConfig // {
+        gpgme = attrs: {
           nativeBuildInputs = [ pkg-config ];
         };
         # the openssl needs the openssl include files
-        openssl = x.openssl // {
+        openssl = attrs: {
           buildInputs = [ openssl ];
         };
-        ruby-magic = x.ruby-magic // {
+        ruby-magic = attrs: {
           buildInputs = [ file ];
           buildFlags = [ "--enable-system-libraries" ];
+        };
+        gitlab-glfm-markdown = attrs: {
+          cargoDeps = rustPlatform.fetchCargoTarball {
+            src = stdenv.mkDerivation {
+              inherit (buildRubyGem { inherit (attrs) gemName version source; })
+                name
+                src
+                unpackPhase
+                nativeBuildInputs
+              ;
+              dontBuilt = true;
+              installPhase = ''
+                cp -R ext/glfm_markdown $out
+                cp Cargo.lock $out
+              '';
+            };
+            hash = "sha256-/rl3CAWyBd9NvbJkq7775x/co5MXoKaOIgtzDufk5bY=";
+          };
+
+          dontBuild = false;
+
+          nativeBuildInputs = [
+            cargo
+            rustc
+            rustPlatform.cargoSetupHook
+            rustPlatform.bindgenHook
+          ];
+
+          preInstall = ''
+            export CARGO_HOME="$PWD/../.cargo/"
+          '';
         };
       };
     groups = [

--- a/pkgs/development/ruby-modules/gem-config/default.nix
+++ b/pkgs/development/ruby-modules/gem-config/default.nix
@@ -312,7 +312,9 @@ in
           cp -R ext/fast_mmaped_file_rs $out
         '';
       };
-      hash = "sha256-XuQZPbFWqPHlrJvllkvLl1FjKeoAUbi8oKDrS2rY1KM=";
+      hash = if lib.versionAtLeast attrs.version "1.1.0"
+        then "sha256-tSyoCEBtMMkFfPynaMx8oc9bO7I+Pf6Y/f3Ld8uwlEE="
+        else "sha256-XuQZPbFWqPHlrJvllkvLl1FjKeoAUbi8oKDrS2rY1KM=";
     };
     nativeBuildInputs = [
       cargo


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [ ] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [22.05 Release Notes (or backporting 21.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2205-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
  - [ ] (Release notes changes) Ran `nixos/doc/manual/md-to-db.sh` to update generated release notes
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).
